### PR TITLE
Support convolution

### DIFF
--- a/fastar/jaxpr_util.py
+++ b/fastar/jaxpr_util.py
@@ -105,9 +105,10 @@ abstract_arrays._DIMENSION_TYPES.add(InfType)
 inf = InfType()
 _neginf = InfType(neg=True)
 
+def abstractify(x):
+  return ShapedArray(np.shape(x), dtypes.result_type(x))
+
 def fastar_jaxpr(flat_fun, *args_flat):
-  def abstractify(x):
-    return ShapedArray(np.shape(x), dtypes.result_type(x))
   in_avals = map(abstractify, args_flat)
   in_pvals = map(pe.PartialVal.unknown, in_avals)
   jaxpr, out_pvals, consts = pe.trace_to_jaxpr(

--- a/fastar/rules.py
+++ b/fastar/rules.py
@@ -319,12 +319,12 @@ def conv_general_dilated_dependency_rule(
                                         lhs_count.shape, *pad_args, pad_config)
   inverse_lhs_perm = np.argsort(lhs_spec)
   inverse_rhs_perm = np.argsort(rhs_spec)
-  return ((np.take(lhs_start, inverse_lhs_perm),
+  return ((np.take(lhs_start, inverse_lhs_perm) if lhs_count.size else None,
            np.take(rhs_start, inverse_rhs_perm)),
-          (laxref.transpose(lhs_count, inverse_lhs_perm),
+          (laxref.transpose(lhs_count, inverse_lhs_perm) if lhs_count.size else None,
            laxref.transpose(rhs_count, inverse_rhs_perm)),
           lambda lhs_slice, rhs_slice: out_transpose(conv(
-            lhs_pad(lhs_transpose(lhs_slice), np.zeros((), lhs.dtype)),
+            lhs_pad(lhs_transpose(lhs_slice) if lhs_count.size else None, np.zeros((), lhs.dtype)),
             rhs_transpose(rhs_slice))))
 
 dependency_rules[lax.conv_general_dilated_p] = conv_general_dilated_dependency_rule

--- a/tests/lazy_lax_test.py
+++ b/tests/lazy_lax_test.py
@@ -325,8 +325,8 @@ def test_broadcast_in_dim(inshape, dtype, outshape, dimensions, rng_factory):
      [(0, 0, 0), (0, 0, 0)],  # no padding
      [(1, 1, 0), (2, 2, 0)],  # only positive edge padding
      [(1, 2, 1), (0, 1, 0)],  # edge padding and interior padding
-     # TODO [(0, 0, 0), (-1, -1, 0)],  # negative padding
-     # TODO [(0, 0, 0), (-2, -2, 4)],  # negative padding and interior padding
+     [(0, 0, 0), (-1, -1, 0)],  # negative padding
+     [(0, 0, 0), (-2, -2, 4)],  # negative padding and interior padding
      [(0, 0, 0), (-2, -3, 1)],  # remove everything in one dimension
    ]
    for dtype in default_dtypes])
@@ -387,7 +387,7 @@ def test_conv_general_dilated(lhs_shape, rhs_shape, dtype, strides,
       lhs, rhs, strides, padding, lhs_dilation, rhs_dilation,
       dimension_numbers, feature_group_count=feature_group_count,
       batch_group_count=batch_group_count)
-  tu.check_lazy_fun(fun, *args, rtol=.005, atol=.1)
+  tu.check_lazy_fun(fun, *args, rtol=.005, atol=.2)
 
 def test_conv_lhs_count():
   lhs_shape = (1, 1, 3, 7)


### PR DESCRIPTION
Supports convs, including dimensions numbers, padding and striding, `lhs_dilation` (transposed convs). `rhs_dilation` (dilated convs) aren't supported yet.

There is potential for optimization, i. e. not evaluating child counts in dependency rules and fusing pad into the valid conv.