### PR TITLE
Update kernel signature to use kwargs, migrate all rules

### DIFF
--- a/fastar/test_util.py
+++ b/fastar/test_util.py
@@ -1,16 +1,12 @@
-from itertools import chain
-from random import shuffle
 import numpy as np
 
 import jax.test_util as jtu
 from jax import lax
 from jax.util import safe_map, safe_zip
-from jax.tree_util import tree_multimap, tree_flatten, tree_map
-from jax import random, ShapeDtypeStruct
-import jax.numpy as jnp
+from jax.tree_util import tree_flatten, tree_map
+from jax import ShapeDtypeStruct
 
 from fastar import delay, force
-from fastar.box_util import getbox
 
 map = safe_map
 zip = safe_zip
@@ -27,8 +23,10 @@ def check(thunk, atol=None, rtol=None):
   jtu.check_close(result, expected, atol, rtol)
 
 def random_box(rng, shape):
-  box_start = rng.randint(shape)
-  box_shape = rng.randint(1, np.subtract(shape, box_start - 1))
+  if np.any(np.less(shape, 0)):
+    raise ValueError
+  box_start = rng.randint(np.maximum(shape, 1))
+  box_shape = rng.randint(np.maximum(shape - (box_start - 1), 1))
   return box_start, box_shape
 
 def random_box_thunk(rng, thunk):


### PR DESCRIPTION
~Has a remaining bug that I will still fix tomorrow.~

~@j-towns: Another bug is the following: Whenever the output slice is empty, the core crashes (reproduce with disabled tests).~

**Update: Both are fixed now.**

I updated `lazy_lax_test.py` directly for a better diff and left `delayed_lax_test.py` untouched for now, we should replace that after merging.